### PR TITLE
Can't use fields attribute from TranslationOptions

### DIFF
--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -94,4 +94,4 @@ class AbstractIndexPage(AbstractBasePage):
 
 
 class HomePage(Page):
-    pass
+    translation_fields = []

--- a/iati/home/translation.py
+++ b/iati/home/translation.py
@@ -9,4 +9,4 @@ from home.translation_helper import add_language_content_panels
 @register(HomePage)
 class HomePageTR(TranslationOptions):
     pass
-add_language_content_panels(HomePage, HomePageTR)
+add_language_content_panels(HomePage)

--- a/iati/home/translation_helper.py
+++ b/iati/home/translation_helper.py
@@ -4,12 +4,11 @@ from wagtail.core.fields import Creator
 from django.utils.translation import gettext_lazy as _
 
 
-def add_language_content_panels(page_model, translation_model):
+def add_language_content_panels(page_model):
     """A function that dynamically adds tabbed content panels depending on the fields defined in the translation model and the languages in settings
 
     Args:
-        page_model (Page): The page model class which needs tabbed content panels
-        translation_model (TranslationOptions): The class from translation.py that contains the fields to be translated
+        page_model (Page): The page model class which needs tabbed content panels. Should have the array translation_fields defined in the page model.
 
     Returns:
         None: This doesn't return anything, it's modifying the provided page_model.
@@ -23,7 +22,7 @@ def add_language_content_panels(page_model, translation_model):
     for language_code, language_name in settings.LANGUAGES:
         multi_field_panel_contents = [FieldPanel("title_{}".format(language_code))]
         stream_field_panel_contents = []
-        for field_name in translation_model.fields:
+        for field_name in page_model.translation_fields:
             localized_field_name = field_name+"_{}".format(language_code)
             field_object = getattr(page_model, localized_field_name)
             if not isinstance(field_object, Creator):
@@ -35,6 +34,6 @@ def add_language_content_panels(page_model, translation_model):
         local_content_panel = [MultiFieldPanel(multi_field_panel_contents)] + stream_field_panel_contents
         edit_handler_contents.append(ObjectList(local_content_panel, heading=language_name))
     promote_and_settings_panels = [ObjectList([MultiFieldPanel(promote_panel_contents)], heading=_('Promote')), ObjectList(page_model.settings_panels, heading=_('Settings'), classname='settings')]
-    if hasattr(translation_model, "multilingual_field_panels"):
-        edit_handler_contents = [ObjectList([field for field in translation_model.multilingual_field_panels], heading=_('Multilingual'))] + edit_handler_contents
+    if hasattr(page_model, "multilingual_field_panels"):
+        edit_handler_contents = [ObjectList([field for field in page_model.multilingual_field_panels], heading=_('Multilingual'))] + edit_handler_contents
     page_model.edit_handler = TabbedInterface(edit_handler_contents + promote_and_settings_panels)

--- a/iati/home/translation_helper.py
+++ b/iati/home/translation_helper.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 def add_language_content_panels(page_model):
-    """A function that dynamically adds tabbed content panels depending on the fields defined in the translation model and the languages in settings
+    """A function that dynamically adds tabbed content panels depending on the fields defined in the page model and the languages in settings
 
     Args:
         page_model (Page): The page model class which needs tabbed content panels. Should have the array translation_fields defined in the page model.


### PR DESCRIPTION
`fields` attribute gets turned into a dict by Django modeltranslation, so we can't rely on it to predictably order the fields to be translated. I've moved fields from the translation.py into respective models.py's, so the TranslationOptions class can just copy it from there. See events/models.py for an example, but the way I've set this up now each model to be translated will need `translated_fields` array and if you want additional panels the `multilingual_field_panels` also goes in the page models now.