### PR TITLE
Remove unnecessary setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,8 @@ pip install -r requirements_dev.txt
 createdb iati-website
 cp settings/local.py.example settings/local.py
 
-# Check database migrations work and execute
-python manage.py check
-python manage.py makemigrations
-python manage.py migrate
-
-# Perform additional migrations for translated fields
+# Make and perform Django migrations AND bespoke translations for translated fields
+# Note this will ask you to approve bespoke SQL commands
 python manage.py makemigrations_translation
 python manage.py migrate_translation
 


### PR DESCRIPTION
`manage.py makemigrations_translation` and `manage.py migrate_translation` extend default django makemigrations and migrate functionality to include database changes for translated content.