### PR TITLE
Allow languages to be activated individually, regardless of languages…

### DIFF
--- a/iati/home/templates/home/includes/translation_links.html
+++ b/iati/home/templates/home/includes/translation_links.html
@@ -1,8 +1,9 @@
 {% load wagtailcore_tags wagtail_modeltranslation i18n %}
-
-<div style="position:absolute;bottom:0;left:0;padding-left:5px;">
+{% if languages|length > 1 %}
+  <div style="position:absolute;bottom:0;left:0;padding-left:5px;">
     {% trans "Language" %}:
     {% for language in languages %}
         <a href="{{ language.url }}">{{ language.code }}</a> {% if not forloop.last %}|{% endif %}
     {% endfor %}
-</div>
+  </div>
+{% endif %}

--- a/iati/home/templatetags/iati_tags.py
+++ b/iati/home/templatetags/iati_tags.py
@@ -1,21 +1,20 @@
-import os
 from django import template
+from django.conf import settings
 from home.models import HomePage
 from about.models import AboutPage
 from contact.models import ContactPage
 from events.models import EventIndexPage
 from guidance_and_support.models import GuidanceAndSupportPage
 from news.models import NewsIndexPage
-
-from django.conf import settings
 from wagtail_modeltranslation.contextlib import use_language
 from wagtail.core.templatetags.wagtailcore_tags import pageurl
 
 register = template.Library()
 
+
 @register.simple_tag(takes_context=True)
 def default_page_url(context, default_page_name="home"):
-    """Returns the relative url for a top-level default page"""
+    """Return the relative url for a top-level default page."""
     page_model_names = {
         'home': HomePage,
         'about': AboutPage,
@@ -31,11 +30,12 @@ def default_page_url(context, default_page_name="home"):
         return ''
     return default_page.get_url(context['request'])
 
-@register.inclusion_tag("home/includes/translation_links.html",takes_context=True)
+
+@register.inclusion_tag("home/includes/translation_links.html", takes_context=True)
 def translation_links(context, calling_page):
-    """Takes the inclusion template 'translation_links.html' and returns a snippet of HTML with links to the requesting page in all offered languages"""
+    """Take the inclusion template 'translation_links.html' and return a snippet of HTML with links to the requesting page in all offered languages."""
     language_results = []
-    for language_code, language_name in settings.LANGUAGES:
+    for language_code, language_name in settings.ACTIVE_LANGUAGES:
         with use_language(language_code):
             language_url = pageurl(context, calling_page)
             language_results.append({"code": language_code, "name": language_name, "url": language_url})

--- a/iati/iati/activate_languages.py
+++ b/iati/iati/activate_languages.py
@@ -1,22 +1,38 @@
-from django.urls import LocalePrefixPattern
+from django.urls import LocalePrefixPattern, URLResolver
 from django.conf import settings
 from django.utils.translation import activate, get_language
 
 
-@property
-def language_prefix(self):
+class ActiveLocalePrefixPattern(LocalePrefixPattern):
     """
-    Overwrite the default language_prefix function within LocalePrefixPattern.
-    This allows us to check for activated languages before resolving URL.
+    Patched version of LocalePrefixPattern for i18n_patterns.
     """
-    language_code = get_language() or settings.LANGUAGE_CODE
-    if language_code not in [active_language_code for active_language_code, active_language_name in settings.ACTIVE_LANGUAGES]:
-        language_code = settings.LANGUAGE_CODE
-        activate(language_code)
-    if language_code == settings.LANGUAGE_CODE and not self.prefix_default_language:
-        return ''
-    return '%s/' % language_code
+
+    @property
+    def language_prefix(self):
+        """
+        Overwrite the default language_prefix function within LocalePrefixPattern.
+        This allows us to check for activated languages before resolving URL.
+        """
+        language_code = get_language() or settings.LANGUAGE_CODE
+        if language_code not in [active_language_code for active_language_code, active_language_name in settings.ACTIVE_LANGUAGES]:
+            language_code = settings.LANGUAGE_CODE
+            activate(language_code)
+        if language_code == settings.LANGUAGE_CODE and not self.prefix_default_language:
+            return ''
+        return '%s/' % language_code
 
 
-del LocalePrefixPattern.language_prefix
-LocalePrefixPattern.language_prefix = language_prefix
+def i18n_patterns(*urls, prefix_default_language=True):
+    """
+    Add the language code prefix to every URL pattern within this function.
+    This may only be used in the root URLconf, not in an included URLconf.
+    """
+    if not settings.USE_I18N:
+        return list(urls)
+    return [
+        URLResolver(
+            ActiveLocalePrefixPattern(prefix_default_language=prefix_default_language),
+            list(urls),
+        )
+    ]

--- a/iati/iati/activate_languages.py
+++ b/iati/iati/activate_languages.py
@@ -15,7 +15,7 @@ class ActiveLocalePrefixPattern(LocalePrefixPattern):
         This allows us to check for activated languages before resolving URL.
         """
         language_code = get_language() or settings.LANGUAGE_CODE
-        if language_code not in [active_language_code for active_language_code, active_language_name in settings.ACTIVE_LANGUAGES]:
+        if language_code not in [active_language_code for active_language_code, _ in settings.ACTIVE_LANGUAGES]:
             language_code = settings.LANGUAGE_CODE
             activate(language_code)
         if language_code == settings.LANGUAGE_CODE and not self.prefix_default_language:

--- a/iati/iati/activate_languages.py
+++ b/iati/iati/activate_languages.py
@@ -1,0 +1,22 @@
+from django.urls import LocalePrefixPattern
+from django.conf import settings
+from django.utils.translation import activate, get_language
+
+
+@property
+def language_prefix(self):
+    """
+    Overwrite the default language_prefix function within LocalePrefixPattern.
+    This allows us to check for activated languages before resolving URL.
+    """
+    language_code = get_language() or settings.LANGUAGE_CODE
+    if language_code not in [active_language_code for active_language_code, active_language_name in settings.ACTIVE_LANGUAGES]:
+        language_code = settings.LANGUAGE_CODE
+        activate(language_code)
+    if language_code == settings.LANGUAGE_CODE and not self.prefix_default_language:
+        return ''
+    return '%s/' % language_code
+
+
+del LocalePrefixPattern.language_prefix
+LocalePrefixPattern.language_prefix = language_prefix

--- a/iati/iati/settings/base.py
+++ b/iati/iati/settings/base.py
@@ -140,6 +140,10 @@ LANGUAGES = [
     ('pt', _('Portuguese')),
 ]
 
+ACTIVE_LANGUAGES = [
+    ('en', _('English')),
+]
+
 TIME_ZONE = 'UTC'
 
 USE_I18N = True

--- a/iati/iati/urls.py
+++ b/iati/iati/urls.py
@@ -9,9 +9,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 from search import views as search_views
 
 # For internationalization.
-# Must import iati.activate_languages first to patch i18n_patterns dependency
-import iati.activate_languages
-from django.conf.urls.i18n import i18n_patterns
+from iati.activate_languages import i18n_patterns
 
 urlpatterns = [
     url(r'^django-admin/', admin.site.urls),

--- a/iati/iati/urls.py
+++ b/iati/iati/urls.py
@@ -8,7 +8,9 @@ from wagtail.documents import urls as wagtaildocs_urls
 
 from search import views as search_views
 
-# For internationalization
+# For internationalization.
+# Must import iati.activate_languages first to patch i18n_patterns dependency
+import iati.activate_languages
 from django.conf.urls.i18n import i18n_patterns
 
 urlpatterns = [


### PR DESCRIPTION
Allow languages to be activated individually, regardless of languages available to CMS. A feature specifically requested by Kate when she realized that our alpha still had "/fr/" as a valid link right now.

We will ideally want to test this not only for resolving the URLs right, but also for thread safety.