### PR TITLE
Test about sub page live server

### DIFF
--- a/iati/conftest.py
+++ b/iati/conftest.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 from iati.settings.local import DJANGO_ADMIN_USER, DJANGO_ADMIN_PASS
 from django.contrib.auth.models import User
 
-LOCALHOST = 'http://127.0.0.1:8000'
+LOCALHOST = 'http://127.0.0.1:8000/'
 os.environ['LIVE_SERVER_URL'] = LOCALHOST
 
 

--- a/iati/conftest.py
+++ b/iati/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 from splinter import Browser
+from django.core.management import call_command
 from iati.settings.local import DJANGO_ADMIN_USER, DJANGO_ADMIN_PASS
+from django.contrib.auth.models import User
 
 LOCALHOST = 'http://127.0.0.1:8000/'
 
@@ -15,11 +17,20 @@ def multibrowser(request):
 
 
 @pytest.fixture(scope='function')
-def admin_browser(browser):
+def admin_browser(browser, live_server):
     """Create a browser that is logged in to the CMS."""
-    browser.visit(LOCALHOST+'admin/')
+    browser.visit(live_server.url+'/admin/')
     browser.fill('username', DJANGO_ADMIN_USER)
     browser.fill('password', DJANGO_ADMIN_PASS)
     sign_in_button = browser.find_by_css("button").first
     sign_in_button.click()
     return browser
+
+
+@pytest.fixture(scope='session')
+def django_db_setup(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        if not User.objects.filter(username=DJANGO_ADMIN_USER).exists():
+            User.objects.create_superuser(DJANGO_ADMIN_USER, "admin@email.com", DJANGO_ADMIN_PASS)
+        call_command('createdefaultpages')
+    return django_db_setup

--- a/iati/conftest.py
+++ b/iati/conftest.py
@@ -1,10 +1,12 @@
+import os
 import pytest
 from splinter import Browser
 from django.core.management import call_command
 from iati.settings.local import DJANGO_ADMIN_USER, DJANGO_ADMIN_PASS
 from django.contrib.auth.models import User
 
-LOCALHOST = 'http://127.0.0.1:8000/'
+LOCALHOST = 'http://127.0.0.1:8000'
+os.environ['LIVE_SERVER_URL'] = LOCALHOST
 
 
 @pytest.fixture(scope='session', params=[
@@ -17,9 +19,9 @@ def multibrowser(request):
 
 
 @pytest.fixture(scope='function')
-def admin_browser(browser, live_server):
+def admin_browser(browser):
     """Create a browser that is logged in to the CMS."""
-    browser.visit(live_server.url+'/admin/')
+    browser.visit(os.environ['LIVE_SERVER_URL']+'/admin/')
     browser.fill('username', DJANGO_ADMIN_USER)
     browser.fill('password', DJANGO_ADMIN_PASS)
     sign_in_button = browser.find_by_css("button").first
@@ -27,8 +29,9 @@ def admin_browser(browser, live_server):
     return browser
 
 
-@pytest.fixture(scope='session')
-def django_db_setup(django_db_setup, django_db_blocker):
+@pytest.fixture(scope='module')
+def django_db_setup(django_db_setup, django_db_blocker, live_server):
+    os.environ['LIVE_SERVER_URL'] = live_server.url
     with django_db_blocker.unblock():
         if not User.objects.filter(username=DJANGO_ADMIN_USER).exists():
             User.objects.create_superuser(DJANGO_ADMIN_USER, "admin@email.com", DJANGO_ADMIN_PASS)

--- a/iati/home/templatetags/iati_tags.py
+++ b/iati/home/templatetags/iati_tags.py
@@ -14,7 +14,13 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def default_page_url(context, default_page_name="home"):
-    """Return the relative url for a top-level default page."""
+    """Return the relative url for a top-level default page.
+
+    Todo:
+        Decide whether or not to check for contexts without request attributes.
+        During pytests, if you don't mark a test to ignore template errors iati_tags will cause failures.
+
+    """
     page_model_names = {
         'home': HomePage,
         'about': AboutPage,

--- a/iati/iati/settings/base.py
+++ b/iati/iati/settings/base.py
@@ -29,6 +29,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 INSTALLED_APPS = [
     'wagtail_modeltranslation',
     'wagtail_modeltranslation.makemigrations',
+    'wagtail_modeltranslation.migrate',
     'home',
     'search',
     'about',

--- a/iati/search/migrations/0001_initial.py
+++ b/iati/search/migrations/0001_initial.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('wagtailcore', '0040_page_draft_title'),
+        ('wagtailsearch', '0003_remove_editors_pick'),
+    ]
+
+    operations = [
+        # migrations.RunSQL('ALTER TABLE wagtailsearch_editorspick DROP CONSTRAINT wagtailsearch_editor_page_id_28cbc274_fk_wagtailco;'),
+        migrations.RunSQL('DROP TABLE IF EXISTS wagtailsearch_editorspick CASCADE;'),
+    ]

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -1,7 +1,9 @@
 """A module of functional tests for the about page and its sub pages."""
 import pytest
+from django.utils.text import slugify
 
 
+@pytest.mark.ignore_template_errors
 @pytest.mark.django_db()
 class TestAboutChildPageCreation():
     """A container for tests to check the ability to creat About child pages."""
@@ -21,6 +23,8 @@ class TestAboutChildPageCreation():
         admin_browser.find_by_text(child_page['page_type']).click()
         admin_browser.find_by_text('English').click()
         admin_browser.fill('title_en', child_page['title'])
+        admin_browser.find_by_text('Promote').click()
+        admin_browser.fill('slug_en', slugify(child_page['title']))
         admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
         admin_browser.find_by_text('Publish').click()
         assert admin_browser.find_by_text(child_page['title'])

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -1,11 +1,10 @@
 """A module of functional tests for the about page and its sub pages."""
-# import pytest
+import pytest
 
 
-# @pytest.mark.django_db()
+@pytest.mark.django_db()
 class TestAboutChildPageCreation():
     """A container for tests to check the ability to creat About child pages."""
-
     def test_can_create_about_sub_page(self, admin_browser):
         """Check that an about sub page can be created for the About page."""
         admin_browser.click_link_by_text('Pages')
@@ -15,6 +14,8 @@ class TestAboutChildPageCreation():
         admin_browser.find_by_text('About sub page').click()
         admin_browser.find_by_text('English').click()
         admin_browser.fill('title_en', 'test sub page')
+        admin_browser.find_by_text('Promote').click()
+        admin_browser.fill('slug_en', 'test-sub-page')
         admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
         admin_browser.find_by_text('Publish').click()
         assert admin_browser.find_by_text('test sub page')
@@ -28,6 +29,8 @@ class TestAboutChildPageCreation():
         admin_browser.find_by_text('Case study index page').click()
         admin_browser.find_by_text('English').click()
         admin_browser.fill('title_en', 'test case study index page')
+        admin_browser.find_by_text('Promote').click()
+        admin_browser.fill('slug_en', 'test-case-study-index-page')
         admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
         admin_browser.find_by_text('Publish').click()
         assert admin_browser.find_by_text('test case study index page')

--- a/iati/tests/base_functional_tests.py
+++ b/iati/tests/base_functional_tests.py
@@ -3,18 +3,35 @@ import pytest
 from conftest import LOCALHOST
 
 
-DEFAULT_PAGE_NAMES = [
-    'about',
-    'contact',
-    'events',
-    'news',
-    'guidance_and_support'
-]
+class TestDefaultPagesExist():
+    """A container for tests that the default pages exist."""
+
+    @pytest.mark.parametrize("page_name", [
+        'about',
+        'contact',
+        'events',
+        'news',
+        'guidance_and_support'
+    ])
+    def test_default_pages_exist(self, browser, page_name):
+        """Check default pages exist."""
+        browser.visit(LOCALHOST + '{}'.format(page_name))
+        page_title = page_name.replace('_', ' ').capitalize()
+        assert browser.title == page_title
 
 
-@pytest.mark.parametrize("page_name", DEFAULT_PAGE_NAMES)
-def test_default_pages_exist(browser, page_name):
-    """Check default pages exist."""
-    browser.visit(LOCALHOST + '{}'.format(page_name))
-    page_title = page_name.replace('_', ' ').capitalize()
-    assert browser.title == page_title
+class TestTopMenu():
+    """A container for tests that the top menu navigation works."""
+
+    @pytest.mark.parametrize('main_section', [
+        'about',
+        'contact',
+        'events',
+        'news',
+        'support'
+    ])
+    def test_top_menu(self, browser, main_section):
+        """Check links to default site pages in the top menu navigate to the expected page."""
+        browser.visit(LOCALHOST)
+        browser.click_link_by_id('section-{}'.format(main_section))
+        assert browser.find_by_css('body').first.has_class('body--{}'.format(main_section))

--- a/iati/tests/functional_tests.py
+++ b/iati/tests/functional_tests.py
@@ -28,29 +28,3 @@ class TestHomePageExists():
         past_url = browser.url
         logo.click()
         assert past_url == browser.url
-
-
-class TestTopMenu():
-    """A container for tests that the top menu navigation works."""
-
-    @pytest.mark.parametrize('main_section', [
-        'about',
-        'contact',
-        'events',
-        'news',
-        'support'
-    ])
-    def test_top_menu(self, browser, main_section):
-        """Check links to default site pages in the top menu navigate to the expected page."""
-        browser.visit(LOCALHOST)
-        browser.click_link_by_id('section-{}'.format(main_section))
-        assert browser.find_by_css('body').first.has_class('body--{}'.format(main_section))
-
-
-class TestAdminLogin():
-    """A container for tests that check admins can login to the CMS."""
-
-    def test_admin_login(self, admin_browser):
-        """Check the Wagtail CMS logo is on the logged in admin page."""
-        wagtail_logo = '//img[@class="wagtail-logo wagtail-logo__body"]'
-        assert admin_browser.find_by_xpath(wagtail_logo).first.visible

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_files = tests.py test_*.py *_tests.py
+addopts = --create-db

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
 python_files = tests.py test_*.py *_tests.py
-addopts = --create-db


### PR DESCRIPTION
Hey Imogen,

This is as far as I got with the tests. The linchpin change was line 32 of settings/base.py. Importing the migrate function explicitly allows that to work and gets rid of the annoying cursor error.

Once I got that working, I realized that we cannot just open a server separately and then change to a testing database. You have to open the server after switching to the testing database, which is why admin_browser inherits from `live_server`. There's a tiny bit of documentation on it here: http://pytest-django.readthedocs.io/en/latest/helpers.html But it's super cool and runs the django server for you.

And unfortunately this also runs us into a long-standing and unsolved wagtail bug here: https://github.com/wagtail/wagtail/issues/1824 If we want the DB changes to be transactional, we need to sqlflush the DB. But evidently wagtail can't do that because of a migration bug their devs don't want to fix. In the issue there someone suggested a migration fix, but I couldn't figure out how to incorporate it.

We should definitely make the `settings/base.py` change to `add-page-models` at which point we won't need `_translation` on any of our commands anymore. And then maybe if we can fix that `wagtailsearch_editorspick` bug...