### PR TITLE
Test case study children

### DIFF
--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -12,7 +12,7 @@ PEOPLE_PAGE = {'page_type': 'People page', 'title': 'test people page'}
 def navigate_to_about_cms(admin_browser):
     """Navigate to the About page section of the CMS."""
     admin_browser.click_link_by_text('Pages')
-    admin_browser.find_by_xpath('//*[@class="icon icon-arrow-right "]').click()
+    admin_browser.find_by_xpath('//span[@class="icon icon-arrow-right "]').click()
     admin_browser.find_by_text('About').click()
 
 
@@ -26,7 +26,7 @@ def enter_page_content(admin_browser, page_type, page_title):
 
 def publish_page(admin_browser):
     """Publish page created in the CMS."""
-    admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
+    admin_browser.find_by_xpath('//div[@class="dropdown-toggle icon icon-arrow-up"]').click()
     admin_browser.find_by_text('Publish').click()
 
 
@@ -37,6 +37,12 @@ def create_about_child_page(admin_browser, page_type, page_title):
     admin_browser.find_by_text(page_type).click()
     enter_page_content(admin_browser, page_type, page_title)
     publish_page(admin_browser)
+
+
+def view_live_page(admin_browser, page_title):
+    """Navigate to the published page on the site."""
+    admin_browser.find_by_text(page_title).mouse_over()
+    admin_browser.find_by_text('View live').click()
 
 
 @pytest.mark.django_db()
@@ -52,8 +58,7 @@ class TestAboutChildPageCreation():
     def test_can_create_about_child_pages(self, admin_browser, child_page):
         """Check that when an about child page is created it appears in the website."""
         create_about_child_page(admin_browser, child_page['page_type'], child_page['title'])
-        admin_browser.find_by_text(child_page['title']).mouse_over()
-        admin_browser.find_by_text('View live').click()
+        view_live_page(admin_browser, child_page['title'])
         assert admin_browser.is_text_present(child_page['title'])
 
 
@@ -70,3 +75,6 @@ class TestCaseStudyIndexChildPageCreation():
         self.setup_case_study_index_page(admin_browser)
         admin_browser.find_by_xpath('//td[@class="no-children"]').click()
         enter_page_content(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], CASE_STUDY_INDEX_PAGE['title'])
+        publish_page(admin_browser)
+        view_live_page(admin_browser, CASE_STUDY_INDEX_PAGE['title'])
+        assert admin_browser.is_text_present(CASE_STUDY_INDEX_PAGE['title'])

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -10,16 +10,16 @@ def navigate_to_about_cms(admin_browser):
     admin_browser.find_by_text('About').click()
 
 
-# def create_a_child_page(admin_browser, page_type, page_title):
-#     """Create a child page in the CMS."""
-#     admin_browser.find_by_text('Add child page').click()
-#     admin_browser.find_by_text(page_type).click()
-#     admin_browser.find_by_text('English').click()
-#     admin_browser.fill('title_en', page_title)
-#     admin_browser.find_by_text('Promote').click()
-#     admin_browser.fill('slug_en', slugify(page_title))
-#     admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
-#     admin_browser.find_by_text('Publish').click()
+def create_a_child_page(admin_browser, page_type, page_title):
+    """Create a child page in the CMS."""
+    admin_browser.find_by_text('Add child page').click()
+    admin_browser.find_by_text(page_type).click()
+    admin_browser.find_by_text('English').click()
+    admin_browser.fill('title_en', page_title)
+    admin_browser.find_by_text('Promote').click()
+    admin_browser.fill('slug_en', slugify(page_title))
+    admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
+    admin_browser.find_by_text('Publish').click()
 
 
 @pytest.mark.django_db()

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -3,6 +3,25 @@ from django.utils.text import slugify
 import pytest
 
 
+def navigate_to_about_cms(admin_browser):
+    """Navigate to the About page section of the CMS."""
+    admin_browser.click_link_by_text('Pages')
+    admin_browser.find_by_xpath('//*[@class="icon icon-arrow-right "]').click()
+    admin_browser.find_by_text('About').click()
+
+
+# def create_a_child_page(admin_browser, page_type, page_title):
+#     """Create a child page in the CMS."""
+#     admin_browser.find_by_text('Add child page').click()
+#     admin_browser.find_by_text(page_type).click()
+#     admin_browser.find_by_text('English').click()
+#     admin_browser.fill('title_en', page_title)
+#     admin_browser.find_by_text('Promote').click()
+#     admin_browser.fill('slug_en', slugify(page_title))
+#     admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
+#     admin_browser.find_by_text('Publish').click()
+
+
 @pytest.mark.django_db()
 class TestAboutChildPageCreation():
     """A container for tests to check the ability to create About child pages."""
@@ -15,9 +34,7 @@ class TestAboutChildPageCreation():
     ])
     def test_can_create_about_child_pages(self, admin_browser, child_page):
         """Check that when an about child page is created it appears in the website."""
-        admin_browser.click_link_by_text('Pages')
-        admin_browser.find_by_xpath('//*[@class="icon icon-arrow-right "]').click()
-        admin_browser.find_by_text('About').click()
+        navigate_to_about_cms(admin_browser)
         admin_browser.find_by_text('Add child page').click()
         admin_browser.find_by_text(child_page['page_type']).click()
         admin_browser.find_by_text('English').click()
@@ -29,3 +46,19 @@ class TestAboutChildPageCreation():
         admin_browser.find_by_text(child_page['title']).mouse_over()
         admin_browser.find_by_text('View live').click()
         assert admin_browser.is_text_present(child_page['title'])
+
+
+@pytest.mark.django_db()
+class TestCaseStudyIndexChildPageCreation():
+    """A container for tests to check the ability to create Case Study pages."""
+
+    def setup_case_study_index_page(self, admin_browser):
+        """Create a Case Study Index page as a child of the About page."""
+        case_study_index_type = 'Case study index page'
+        case_study_index_title = 'test case study index parent page'
+        navigate_to_about_cms(admin_browser)
+
+
+    def test_can_create_case_study_pages(self, admin_browser):
+        """Check that a Case Study page can be created as a child of the Case Study Index page."""
+        self.setup_case_study_index_page(admin_browser)

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -3,6 +3,12 @@ from django.utils.text import slugify
 import pytest
 
 
+ABOUT_SUB_PAGE = {'page_type': 'About sub page', 'title': 'test sub page'}
+CASE_STUDY_INDEX_PAGE = {'page_type': 'Case study index page', 'title': 'test case study index page'}
+HISTORY_PAGE = {'page_type': 'History page', 'title': 'test history page'}
+PEOPLE_PAGE = {'page_type': 'People page', 'title': 'test people page'}
+
+
 def navigate_to_about_cms(admin_browser):
     """Navigate to the About page section of the CMS."""
     admin_browser.click_link_by_text('Pages')
@@ -10,16 +16,27 @@ def navigate_to_about_cms(admin_browser):
     admin_browser.find_by_text('About').click()
 
 
-def create_a_child_page(admin_browser, page_type, page_title):
-    """Create a child page in the CMS."""
-    admin_browser.find_by_text('Add child page').click()
-    admin_browser.find_by_text(page_type).click()
+def enter_page_content(admin_browser, page_type, page_title):
+    """Add title and slug to a page in the CMS."""
     admin_browser.find_by_text('English').click()
     admin_browser.fill('title_en', page_title)
     admin_browser.find_by_text('Promote').click()
     admin_browser.fill('slug_en', slugify(page_title))
+
+
+def publish_page(admin_browser):
+    """Publish page created in the CMS."""
     admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
     admin_browser.find_by_text('Publish').click()
+
+
+def create_about_child_page(admin_browser, page_type, page_title):
+    """Create a child page in the CMS."""
+    navigate_to_about_cms(admin_browser)
+    admin_browser.find_by_text('Add child page').click()
+    admin_browser.find_by_text(page_type).click()
+    enter_page_content(admin_browser, page_type, page_title)
+    publish_page(admin_browser)
 
 
 @pytest.mark.django_db()
@@ -27,22 +44,14 @@ class TestAboutChildPageCreation():
     """A container for tests to check the ability to create About child pages."""
 
     @pytest.mark.parametrize('child_page', [
-        {'page_type': 'About sub page', 'title': 'test sub page'},
-        {'page_type': 'Case study index page', 'title': 'test case study index page'},
-        {'page_type': 'History page', 'title': 'test history page'},
-        {'page_type': 'People page', 'title': 'test people page'}
+        ABOUT_SUB_PAGE,
+        CASE_STUDY_INDEX_PAGE,
+        HISTORY_PAGE,
+        PEOPLE_PAGE
     ])
     def test_can_create_about_child_pages(self, admin_browser, child_page):
         """Check that when an about child page is created it appears in the website."""
-        navigate_to_about_cms(admin_browser)
-        admin_browser.find_by_text('Add child page').click()
-        admin_browser.find_by_text(child_page['page_type']).click()
-        admin_browser.find_by_text('English').click()
-        admin_browser.fill('title_en', child_page['title'])
-        admin_browser.find_by_text('Promote').click()
-        admin_browser.fill('slug_en', slugify(child_page['title']))
-        admin_browser.find_by_xpath('//*[@class="dropdown-toggle icon icon-arrow-up"]').click()
-        admin_browser.find_by_text('Publish').click()
+        create_about_child_page(admin_browser, child_page['page_type'], child_page['title'])
         admin_browser.find_by_text(child_page['title']).mouse_over()
         admin_browser.find_by_text('View live').click()
         assert admin_browser.is_text_present(child_page['title'])
@@ -54,11 +63,10 @@ class TestCaseStudyIndexChildPageCreation():
 
     def setup_case_study_index_page(self, admin_browser):
         """Create a Case Study Index page as a child of the About page."""
-        case_study_index_type = 'Case study index page'
-        case_study_index_title = 'test case study index parent page'
-        navigate_to_about_cms(admin_browser)
-
+        create_about_child_page(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], CASE_STUDY_INDEX_PAGE['title'])
 
     def test_can_create_case_study_pages(self, admin_browser):
         """Check that a Case Study page can be created as a child of the Case Study Index page."""
         self.setup_case_study_index_page(admin_browser)
+        admin_browser.find_by_xpath('//td[@class="no-children"]').click()
+        enter_page_content(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], CASE_STUDY_INDEX_PAGE['title'])

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -68,13 +68,16 @@ class TestCaseStudyIndexChildPageCreation():
 
     def setup_case_study_index_page(self, admin_browser):
         """Create a Case Study Index page as a child of the About page."""
-        create_about_child_page(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], CASE_STUDY_INDEX_PAGE['title'])
+        case_study_index_page_title = 'test case study index page 2'
+        create_about_child_page(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], case_study_index_page_title)
 
     def test_can_create_case_study_pages(self, admin_browser):
         """Check that a Case Study page can be created as a child of the Case Study Index page."""
         self.setup_case_study_index_page(admin_browser)
         admin_browser.find_by_xpath('//td[@class="no-children"]').click()
-        enter_page_content(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], CASE_STUDY_INDEX_PAGE['title'])
+        case_study_page_type = 'Case study page'
+        case_study_page_title = 'test case study page'
+        enter_page_content(admin_browser, case_study_page_type, case_study_page_title)
         publish_page(admin_browser)
-        view_live_page(admin_browser, CASE_STUDY_INDEX_PAGE['title'])
-        assert admin_browser.is_text_present(CASE_STUDY_INDEX_PAGE['title'])
+        view_live_page(admin_browser, case_study_page_title)
+        assert admin_browser.is_text_present(case_study_page_title)


### PR DESCRIPTION
Complete test setup
Refactor module helper functions
Refactor TestAboutChildPageCreation to incorporate module helper functions
Refactor TestAboutChildPageCreationt to better specify CSS elements by xpath
Found xpath that only returns one result for adding a child page to the Case Studies Index page in order to avoid having to rely on an arbitrary index position in a list of results
Complete test to check the created Case Study page is available in the website

Only checks case study pages are created, will keep these changes self-contained and create a new branch for other CMS tests for pages using the About app models.