### PR TITLE
Set DJANGO_SETTINGS_MODULE in pytest settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - tar -xzf geckodriver*.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
   - pip install -r iati/requirements_dev.txt
-  - export DJANGO_SETTINGS_MODULE=iati.settings.dev
   - psql -c "CREATE DATABASE travisci;" -U postgres  # Must match DB name in iati.settings.dev
   - python iati/manage.py makemigrations_translation
   - python iati/manage.py migrate_translation --no-input
@@ -37,7 +36,6 @@ jobs:
             - tar -xzf geckodriver*.tar.gz -C geckodriver
             - export PATH=$PATH:$PWD/geckodriver
             - pip install -r iati/requirements_dev.txt
-            - export DJANGO_SETTINGS_MODULE=iati.settings.dev
             - psql -c "CREATE DATABASE travisci;" -U postgres  # Must match DB name in iati.settings.dev
             - python iati/manage.py makemigrations_translation
             - python iati/manage.py migrate_translation --no-input

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+DJANGO_SETTINGS_MODULE = iati.settings.dev
 python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
This prevents the need to set DJANGO_SETTINGS_MODULE as an environment variable. In doing so, this makes the code more portable.