### PR TITLE
Pins dependcies to specific versions

### DIFF
--- a/iati/requirements.txt
+++ b/iati/requirements.txt
@@ -1,5 +1,5 @@
-Django>=2.0,<2.1
-psycopg2-binary==2.7.4,<2.8
-wagtail>=2.0,<2.1
-wagtail-modeltranslation>= 0.8.1
+Django==2.0.5
+psycopg2-binary==2.7.4
+wagtail==2.0.1
+wagtail-modeltranslation==0.8.1
 git+https://github.com/deschler/django-modeltranslation


### PR DESCRIPTION
Change made following issues with dev machines (and travis) being on different versions.

Version numbers have been taken from latest passing Travis build.

Will look at if it is possible to pin `django-modeltranslation` in a seperate PR.