### PR TITLE
Download django-modeltranslation==0.13b1 from pip

### DIFF
--- a/iati/requirements.txt
+++ b/iati/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.0.5
+django-modeltranslation==0.13b1
 psycopg2-binary==2.7.4
 wagtail==2.0.1
 wagtail-modeltranslation==0.8.1
-git+https://github.com/deschler/django-modeltranslation


### PR DESCRIPTION
Downloads from a pinned version on pip for consistency with other dependencies. Additionally pining to this version reduces the chance of breaking changes causing dev/travis build issues.