### PR TITLE
Editable home header text

### DIFF
--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -130,7 +130,7 @@ class AbstractIndexPage(AbstractBasePage):
         abstract = True
 
 
-class HomePage(Page):  # pylint: disable=too-many-ancestors
+class HomePage(AbstractBasePage):  # pylint: disable=too-many-ancestors
     """Proof-of-concept model definition for the homepage."""
     header_image = models.ForeignKey(
         'wagtailimages.Image',
@@ -140,7 +140,6 @@ class HomePage(Page):  # pylint: disable=too-many-ancestors
         related_name='+',
         help_text='This is the image that will appear in the header banner at the top of the Home Page. If no image is added a placeholder image will be used.'
     )
-    translation_fields = []
     multilingual_field_panels = [
         ImageChooserPanel('header_image')
     ]

--- a/iati/home/templates/home/includes/hero_heading.html
+++ b/iati/home/templates/home/includes/hero_heading.html
@@ -2,9 +2,9 @@
 
 <div class="row">
     <div class="hero__caption">
-        <h1 class="hero__heading">International Aid Transparency Initiative</h1>
+        <h1 class="hero__heading">{{ page.heading }}</h1>
 
-        <p class="hero__subheading">IATI is a common format to share data on aid and development for better decision making and outcomes</p>
+        <p class="hero__subheading">{{ page.excerpt }}</p>
     </div>
     <div class="hero__emblem">
       {% if page.header_image %}

--- a/iati/home/translation.py
+++ b/iati/home/translation.py
@@ -2,11 +2,12 @@ from .models import HomePage
 from modeltranslation.translator import TranslationOptions
 from modeltranslation.decorators import register
 
-from wagtail.core.models import Page
-
 from home.translation_helper import add_language_content_panels
+
 
 @register(HomePage)
 class HomePageTR(TranslationOptions):
-    pass
+    fields = HomePage.translation_fields
+
+
 add_language_content_panels(HomePage)

--- a/iati/tests/home_functional_tests.py
+++ b/iati/tests/home_functional_tests.py
@@ -1,1 +1,55 @@
 """A module of functional tests for the home page."""
+import pytest
+from tests.base_functional_tests import click_obscured
+
+HOME_PAGE = {
+    'title': 'Home',
+    'heading': 'Test International Aid Transparency Initiative',
+    'excerpt': 'This is an excerpt for the Home page'
+}
+
+
+@pytest.mark.django_db
+class TestHomePage():
+    """A container for tests to check functionality of the Home Page."""
+
+    def navigate_to_edit_home_page(self, admin_browser):
+        """Navigate to the editable section of the CMS for the Home Page."""
+        admin_browser.click_link_by_text('Pages')
+        admin_browser.find_by_xpath('//h3').find_by_text('Home').click()
+        admin_browser.click_link_by_text('Home')
+
+    def publish_changes(self, admin_browser):
+        """Publish changes made in the CMS to the live page."""
+        click_obscured(admin_browser, admin_browser.find_by_xpath('//div[@class="dropdown-toggle icon icon-arrow-up"]').first)
+        click_obscured(admin_browser, admin_browser.find_by_text('Publish').first)
+
+    def view_live_page(self, admin_browser):
+        """Visit the url of the 'View live' button so tests don't open a new window"""
+        top_view_live_button = admin_browser.find_by_text('View live').first
+        page_url = top_view_live_button._element.get_property('href')
+        admin_browser.visit(page_url)
+
+    def test_can_edit_home_page_heading(self, admin_browser):
+        """Check that the Home page heading can be edited."""
+        self.navigate_to_edit_home_page(admin_browser)
+        # Click the English tab
+        admin_browser.find_by_text('English').click()
+        # Fill the heading field
+        admin_browser.fill('heading_en', HOME_PAGE['heading'])
+        # Publish new page heading
+        self.publish_changes(admin_browser)
+        self.view_live_page(admin_browser)
+        assert admin_browser.find_by_text(HOME_PAGE['heading'])
+
+    def test_can_edit_home_page_excerpt(self, admin_browser):
+        """Check that the Home page excerpt can be edited."""
+        self.navigate_to_edit_home_page(admin_browser)
+        # Click the English tab
+        admin_browser.find_by_text('English').click()
+        # Fill the excerpt field
+        admin_browser.fill('excerpt_en', HOME_PAGE['excerpt'])
+        # Publish new page excerpt
+        self.publish_changes(admin_browser)
+        self.view_live_page(admin_browser)
+        assert admin_browser.find_by_text(HOME_PAGE['excerpt'])


### PR DESCRIPTION
Got some functional replication but I think that should get fixed in a different scope as we need to consolidate and refactor a bunch of our existing tests anyway.