### PR TITLE
Standard page models

### DIFF
--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -137,8 +137,12 @@ class HomePage(Page):  # pylint: disable=too-many-ancestors
 
 class StandardPage(AbstractContentPage):
     """A standard content page for generic use, i.e. a Privacy page."""
-    privacy_page = models.BooleanField(default=False)
+    FIXED_PAGE_TYPES = (
+        ("p", "Privacy"),
+        ("t", "Terms and conditions")
+    )
+    fixed_page_type = models.CharField(max_length=1, choices=FIXED_PAGE_TYPES, null=True, blank=True)
 
     multilingual_field_panels = [
-        FieldPanel('privacy_page')
+        FieldPanel('fixed_page_type'),
     ]

--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django import forms
 from wagtail.core.models import Page
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-
+from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.core.blocks import TextBlock, StructBlock, StreamBlock, FieldBlock, CharBlock, RichTextBlock, RawHTMLBlock
 from wagtail.core.fields import StreamField
 from wagtail.images.blocks import ImageChooserBlock
@@ -133,3 +133,12 @@ class AbstractIndexPage(AbstractBasePage):
 class HomePage(Page):  # pylint: disable=too-many-ancestors
     """Proof-of-concept model definition for the homepage."""
     translation_fields = []
+
+
+class StandardPage(AbstractContentPage):
+    """A standard content page for generic use, i.e. a Privacy page."""
+    privacy_page = models.BooleanField(default=False)
+
+    multilingual_field_panels = [
+        FieldPanel('privacy_page')
+    ]

--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -138,10 +138,10 @@ class HomePage(Page):  # pylint: disable=too-many-ancestors
 class StandardPage(AbstractContentPage):
     """A standard content page for generic use, i.e. a Privacy page."""
     FIXED_PAGE_TYPES = (
-        ("p", "Privacy"),
-        ("t", "Terms and conditions")
+        ("privacy", "Privacy"),
+        ("terms", "Terms and conditions")
     )
-    fixed_page_type = models.CharField(max_length=1, choices=FIXED_PAGE_TYPES, null=True, blank=True)
+    fixed_page_type = models.CharField(max_length=7, choices=FIXED_PAGE_TYPES, null=True, blank=True)
 
     multilingual_field_panels = [
         FieldPanel('fixed_page_type'),

--- a/iati/home/templates/home/standard_page.html
+++ b/iati/home/templates/home/standard_page.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block body_class %}body body--{% endblock %}
+{% block body_id %}body-{% endblock %}
+{% block content %}
+
+<div class="hero hero--minor">
+  <div class="row">
+    <div class="max-meter max-meter--center">
+      <div class="hero__caption">
+        <h1 class="hero__heading">{{ page.heading }}</h1>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="l-standard">
+  <div class="row">
+    <div class="max-meter max-meter--center">
+      {% if page.content_editor %}
+        {% include "home/includes/streamfield.html" with content=page.content_editor %}
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/iati/home/templatetags/iati_tags.py
+++ b/iati/home/templatetags/iati_tags.py
@@ -2,7 +2,7 @@ from django import template
 from django.conf import settings
 from django.utils import timezone
 from django.template.defaultfilters import date as _date
-from home.models import HomePage
+from home.models import HomePage, StandardPage
 from about.models import AboutPage
 from contact.models import ContactPage
 from events.models import EventIndexPage, EventType, FeaturedEvent
@@ -40,6 +40,18 @@ def default_page_url(context, default_page_name="home"):
     if not hasattr(context, 'request'):
         return ''
     return default_page.get_url(context['request'])
+
+
+@register.simple_tag(takes_context=True)
+def privacy_page_url(context):
+    """Return the relative url for a privacy page."""
+    privacy_page = StandardPage.objects.live().filter(privacy_page=True).first()
+    if privacy_page is None:
+        return ''
+    if not hasattr(context, 'request'):
+        return ''
+    return privacy_page.get_url(context['request'])
+
 
 
 @register.inclusion_tag("home/includes/translation_links.html", takes_context=True)

--- a/iati/home/templatetags/iati_tags.py
+++ b/iati/home/templatetags/iati_tags.py
@@ -35,9 +35,7 @@ def default_page_url(context, default_page_name="home"):
 
     default_page = page_model_names[default_page_name].objects.live().first()
 
-    if default_page is None:
-        return ''
-    if not hasattr(context, 'request'):
+    if default_page is None or not hasattr(context, 'request'):
         return ''
     return default_page.get_url(context['request'])
 
@@ -46,12 +44,9 @@ def default_page_url(context, default_page_name="home"):
 def standard_page_url(context, page_type):
     """Return the relative url for other fixed pages based on the StandardPage."""
     standard_page = StandardPage.objects.live().filter(fixed_page_type=page_type).first()
-    if standard_page is None:
-        return ''
-    if not hasattr(context, 'request'):
+    if standard_page is None or not hasattr(context, 'request'):
         return ''
     return standard_page.get_url(context['request'])
-
 
 
 @register.inclusion_tag("home/includes/translation_links.html", takes_context=True)

--- a/iati/home/templatetags/iati_tags.py
+++ b/iati/home/templatetags/iati_tags.py
@@ -43,14 +43,14 @@ def default_page_url(context, default_page_name="home"):
 
 
 @register.simple_tag(takes_context=True)
-def privacy_page_url(context):
-    """Return the relative url for a privacy page."""
-    privacy_page = StandardPage.objects.live().filter(privacy_page=True).first()
-    if privacy_page is None:
+def standard_page_url(context, page_type):
+    """Return the relative url for other fixed pages based on the StandardPage."""
+    standard_page = StandardPage.objects.live().filter(fixed_page_type=page_type).first()
+    if standard_page is None:
         return ''
     if not hasattr(context, 'request'):
         return ''
-    return privacy_page.get_url(context['request'])
+    return standard_page.get_url(context['request'])
 
 
 

--- a/iati/home/translation.py
+++ b/iati/home/translation.py
@@ -12,5 +12,5 @@ add_language_content_panels(HomePage)
 
 @register(StandardPage)
 class StandardPageTR(TranslationOptions):
-    translation_fields = StandardPage.translation_fields
+    fields = StandardPage.translation_fields
 add_language_content_panels(StandardPage)

--- a/iati/home/translation.py
+++ b/iati/home/translation.py
@@ -1,12 +1,16 @@
-from .models import HomePage
+from .models import HomePage, StandardPage
 from modeltranslation.translator import TranslationOptions
 from modeltranslation.decorators import register
-
-from wagtail.core.models import Page
-
 from home.translation_helper import add_language_content_panels
+
 
 @register(HomePage)
 class HomePageTR(TranslationOptions):
     pass
 add_language_content_panels(HomePage)
+
+
+@register(StandardPage)
+class StandardPageTR(TranslationOptions):
+    translation_fields = StandardPage.translation_fields
+add_language_content_panels(StandardPage)

--- a/iati/iati/templates/base.html
+++ b/iati/iati/templates/base.html
@@ -149,7 +149,7 @@
 					<ul class="footer__list">
 						<li><a href="{% default_page_url 'contact' %}">Contact</a></li>
 						<li><a href="{% default_page_url %}">Terms and conditions</a></li>
-						<li><a href="https://www.aidtransparency.net/privacy-policy">Privacy policy</a></li>
+						<li><a href="{% privacy_page_url %}">Privacy policy</a></li>
 					</ul>
 				</div>
 				<div class="l-3up__col">

--- a/iati/iati/templates/base.html
+++ b/iati/iati/templates/base.html
@@ -148,8 +148,8 @@
 					<h4 class="footer__heading">Useful links</h4>
 					<ul class="footer__list">
 						<li><a href="{% default_page_url 'contact' %}">Contact</a></li>
-						<li><a href="{% standard_page_url 't' %}">Terms and conditions</a></li>
-						<li><a href="{% standard_page_url 'p' %}">Privacy policy</a></li>
+						<li><a href="{% standard_page_url 'terms' %}">Terms and conditions</a></li>
+						<li><a href="{% standard_page_url 'privacy' %}">Privacy policy</a></li>
 					</ul>
 				</div>
 				<div class="l-3up__col">

--- a/iati/iati/templates/base.html
+++ b/iati/iati/templates/base.html
@@ -148,8 +148,8 @@
 					<h4 class="footer__heading">Useful links</h4>
 					<ul class="footer__list">
 						<li><a href="{% default_page_url 'contact' %}">Contact</a></li>
-						<li><a href="{% default_page_url %}">Terms and conditions</a></li>
-						<li><a href="{% privacy_page_url %}">Privacy policy</a></li>
+						<li><a href="{% standard_page_url 't' %}">Terms and conditions</a></li>
+						<li><a href="{% standard_page_url 'p' %}">Privacy policy</a></li>
 					</ul>
 				</div>
 				<div class="l-3up__col">

--- a/iati/tests/events_functional_tests.py
+++ b/iati/tests/events_functional_tests.py
@@ -10,18 +10,23 @@ from django.utils.text import slugify
 from base_functional_tests import find_and_click_add_button, find_and_click_toggle_button, fill_content_editor_block
 
 
-PRIVACY_PAGE = {
-    'page_type': 'Standard page',
-    'title': 'Privacy page',
-    'heading': 'Privacy page header',
-    'excerpt': 'Privacy page excerpt'
+EVENT_INDEX_PAGE = {
+    'title': 'Events',
+    'heading': 'Test IATI Events',
+    'excerpt': 'This is an excerpt for the Event Index Page'
 }
-TERMS_PAGE = {
-    'page_type': 'Standard page',
-    'title': 'Terms and conditions page',
-    'heading': 'Terms and conditions page header',
-    'excerpt': 'Terms and conditions page excerpt'
+EVENT_PAGE = {
+    'page_type': 'Event page',
+    'title': 'test event page',
+    'heading': 'Test Event Page Heading',
+    'excerpt': 'This is an excerpt for an Test Event page'
 }
+
+TEST_CATEGORY = "Test event type"
+
+H2 = {'content': 'H2 heading', 'button': 'H2', 'id': 'content_editor_en-{}-value'}
+H3 = {'content': 'H3 heading', 'button': 'H3', 'id': 'content_editor_en-{}-value'}
+H4 = {'content': 'H4 heading', 'button': 'H4', 'id': 'content_editor_en-{}-value'}
 
 
 def navigate_to_default_page_cms_section(admin_browser, default_page_title):

--- a/iati/tests/events_functional_tests.py
+++ b/iati/tests/events_functional_tests.py
@@ -10,23 +10,18 @@ from django.utils.text import slugify
 from base_functional_tests import find_and_click_add_button, find_and_click_toggle_button, fill_content_editor_block
 
 
-EVENT_INDEX_PAGE = {
-    'title': 'Events',
-    'heading': 'Test IATI Events',
-    'excerpt': 'This is an excerpt for the Event Index Page'
+PRIVACY_PAGE = {
+    'page_type': 'Standard page',
+    'title': 'Privacy page',
+    'heading': 'Privacy page header',
+    'excerpt': 'Privacy page excerpt'
 }
-EVENT_PAGE = {
-    'page_type': 'Event page',
-    'title': 'test event page',
-    'heading': 'Test Event Page Heading',
-    'excerpt': 'This is an excerpt for an Test Event page'
+TERMS_PAGE = {
+    'page_type': 'Standard page',
+    'title': 'Terms and conditions page',
+    'heading': 'Terms and conditions page header',
+    'excerpt': 'Terms and conditions page excerpt'
 }
-
-TEST_CATEGORY = "Test event type"
-
-H2 = {'content': 'H2 heading', 'button': 'H2', 'id': 'content_editor_en-{}-value'}
-H3 = {'content': 'H3 heading', 'button': 'H3', 'id': 'content_editor_en-{}-value'}
-H4 = {'content': 'H4 heading', 'button': 'H4', 'id': 'content_editor_en-{}-value'}
 
 
 def navigate_to_default_page_cms_section(admin_browser, default_page_title):

--- a/iati/tests/home_functional_tests.py
+++ b/iati/tests/home_functional_tests.py
@@ -6,14 +6,14 @@ from django.utils.text import slugify
 
 PRIVACY_PAGE = {
     'page_type': 'Standard page',
-    'fixed_page_type': 'p',
+    'fixed_page_type': 'privacy',
     'title': 'Privacy page',
     'heading': 'Privacy page header',
     'base_link_text': 'Privacy policy'
 }
 TERMS_PAGE = {
     'page_type': 'Standard page',
-    'fixed_page_type': 't',
+    'fixed_page_type': 'terms',
     'title': 'Terms and conditions page',
     'heading': 'Terms and conditions page header',
     'base_link_text': 'Terms and conditions'
@@ -38,7 +38,7 @@ def enter_page_content(admin_browser, tab_name, cms_field, cms_content):
 
 
 def publish_page(admin_browser):
-    """Publish page created in the CMS."""
+    """Publish page created in the CMS. A duplicate function from about_functional_tests.py."""
     admin_browser.find_by_xpath('//div[@class="dropdown-toggle icon icon-arrow-up"]').click()
     admin_browser.find_by_text('Publish').click()
 
@@ -48,7 +48,7 @@ def create_standard_home_page(admin_browser, page_type, fixed_page_type, page_ti
 
     Args:
         page_type (str): The verbose name of the page model type you want to click on.
-        fixed_page_type (str): The value of the fixed page dropdown (e.g. "p" for "privacy")
+        fixed_page_type (str): The value of the fixed page dropdown (e.g. "privacy" for "PrivacyPage")
         page_title (str): The title of the page you are editing.
 
     """

--- a/iati/tests/home_functional_tests.py
+++ b/iati/tests/home_functional_tests.py
@@ -1,1 +1,90 @@
 """A module of functional tests for the home page."""
+import os
+import pytest
+from django.utils.text import slugify
+
+
+PRIVACY_PAGE = {
+    'page_type': 'Standard page',
+    'fixed_page_type': 'p',
+    'title': 'Privacy page',
+    'heading': 'Privacy page header',
+    'base_link_text': 'Privacy policy'
+}
+TERMS_PAGE = {
+    'page_type': 'Standard page',
+    'fixed_page_type': 't',
+    'title': 'Terms and conditions page',
+    'heading': 'Terms and conditions page header',
+    'base_link_text': 'Terms and conditions'
+}
+
+
+def enter_page_content(admin_browser, tab_name, cms_field, cms_content):
+    """Add title and slug to a page in the CMS.
+
+    Args:
+        tab_name (str): The name of a tab on an edit page of the CMS.
+        cms_field (str): The name of the field in the CMS you want to fill.
+        cms_content (str): The text content you want to fill the field with.
+
+    """
+    tab = admin_browser.find_by_text(tab_name)
+    _ = tab[0].__dict__['_element'].location_once_scrolled_into_view
+    tab[0].click()
+    elem = admin_browser.find_by_css("[name='{}']".format(cms_field))
+    _ = elem[0].__dict__['_element'].location_once_scrolled_into_view
+    admin_browser.fill(cms_field, cms_content)
+
+
+def publish_page(admin_browser):
+    """Publish page created in the CMS."""
+    admin_browser.find_by_xpath('//div[@class="dropdown-toggle icon icon-arrow-up"]').click()
+    admin_browser.find_by_text('Publish').click()
+
+
+def create_standard_home_page(admin_browser, page_type, fixed_page_type, page_title):
+    """Create a child page in the CMS.
+
+    Args:
+        page_type (str): The verbose name of the page model type you want to click on.
+        fixed_page_type (str): The value of the fixed page dropdown (e.g. "p" for "privacy")
+        page_title (str): The title of the page you are editing.
+
+    """
+    admin_browser.visit(os.environ['LIVE_SERVER_URL'] + "/admin/pages/3/")
+    admin_browser.find_by_text('Add child page').click()
+    admin_browser.find_by_text(page_type).click()
+    dropdown = admin_browser.find_by_id("id_fixed_page_type")[0]
+    dropdown.select(fixed_page_type)
+    enter_page_content(admin_browser, 'English', 'title_en', page_title)
+    enter_page_content(admin_browser, 'Promote', 'slug_en', slugify(page_title))
+    publish_page(admin_browser)
+
+
+def view_live_page(admin_browser, page_title):
+    """Navigate to the published page on the site.
+
+    Args:
+        page_title (str): The page title text you are expecting on the live page.
+
+    """
+    button_links = admin_browser.find_by_xpath('//a[@title="View live version of \'{}\'"]'.format(page_title))
+    href = button_links[0].__dict__['_element'].get_property('href')
+    admin_browser.visit(href)
+
+
+@pytest.mark.django_db
+class TestFixedStandardPages():
+    """Tests to see if fixed standard pages are properly linked"""
+    @pytest.mark.parametrize('fixed_page', [
+        PRIVACY_PAGE,
+        TERMS_PAGE
+    ])
+    def test_can_create_standard_pages(self, admin_browser, fixed_page):
+        """Check that when an event index child page is created it appears in the website."""
+        create_standard_home_page(admin_browser, fixed_page['page_type'], fixed_page['fixed_page_type'], fixed_page['title'])
+        view_live_page(admin_browser, fixed_page['title'])
+        assert admin_browser.title == fixed_page['title']
+        admin_browser.click_link_by_text(fixed_page['base_link_text'])
+        assert admin_browser.title == fixed_page['title']


### PR DESCRIPTION
Standard page template, abstract content page model with `fixed_page_type` choice field anticipating two special uses of this page for the `privacy page` and the `terms and conditions page`. Re-usable otherwise.