### PR TITLE
Working case study query and filter

### DIFF
--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -1,6 +1,7 @@
 """Model definitions for the home app."""
 
 from django.db import models
+from django.apps import apps
 from django import forms
 from wagtail.core.models import Page
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -133,3 +134,11 @@ class AbstractIndexPage(AbstractBasePage):
 class HomePage(Page):  # pylint: disable=too-many-ancestors
     """Proof-of-concept model definition for the homepage."""
     translation_fields = []
+
+    def get_context(self, request):
+        """Overwriting the default get_context page to serve descendant case study pages"""
+        CaseStudyPage = apps.get_model(app_label='about', model_name='CaseStudyPage')
+        case_studies = CaseStudyPage.objects.live().descendant_of(self).specific()
+        context = super(HomePage, self).get_context(request)
+        context['case_studies'] = case_studies
+        return context

--- a/iati/home/templates/home/home_page.html
+++ b/iati/home/templates/home/home_page.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load wagtail_modeltranslation wagtailimages_tags %}
 
 {% block body_class %}body body--home{% endblock %}
 {% block body_id %}body-home{% endblock %}
@@ -109,38 +110,43 @@
             </div>
         </div>
     </div>
+    {% if case_studies|length > 0 %}
     <div class="section section-alt-bottom">
         <div class="row">
             <h2 class="section__heading">Case studies</h2>
+
             <div class="max-meter is-typeset is-typeset--article">
                 <p class="section__copy">Duis sit amet aliquam enim. Donec tempus nisi est, vel finibus dolor finibus sit amet. Pellentesque maximus sollicitudin urna.</p>
             </div>
             <div class="l-2up">
-                <div class="l-2up__col">
-                    <div class="help help--standout">
-                        <div class="help__header help__header--big background-cover" style="background-image: url(/static/assets/img/case-study1.png)">
-                            <div class="help__panel fill-sunset">
-                                <h3 class="help__heading">Lorem ipsum dolor sit amet</h3>
-                                <p> Sed mattis orci eu nunc molestie placerat. In ultricies tellus at lorem porttitor fermentum.</p>
-                                <a href="#" title="Under construction">Read more</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="l-2up__col">
-                    <div class="help help--standout">
-                        <div class="help__header background-cover" style="background-image: url(/static/assets/img/case-study2.png)">
-                            <div class="help__panel fill-sunset">
-                                <h3 class="help__heading">Lorem ipsum dolor sit amet</h3>
-                                <p> Sed mattis orci eu nunc molestie placerat. In ultricies tellus at lorem porttitor fermentum.</p>
-                                <a href="#none">Read more</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+
+              {% for case_study in case_studies %}
+                {% if forloop.counter < 3 %}
+                  <div class="l-2up__col">
+                      <div class="help help--standout">
+                        {% if case_study.feed_image %}
+                          {% image case_study.feed_image width-600 as img %}
+                          <div class="help__header help__header--big background-cover" style="background-image: url({{ img.url }})">
+                        {% else %}
+                          <div class="help__header help__header--big background-cover" style="background-image: url(/static/assets/img/image-placeholder.svg)">
+                        {% endif %}
+
+                              <div class="help__panel fill-sunset">
+                                  <h3 class="help__heading">{{ case_study.heading }}</h3>
+                                  <p> {{ case_study.excerpt }}</p>
+                                  <a href="{% slugurl_trans case_study.slug %}">Read more</a>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+                {% endif %}
+              {% endfor %}
+
             </div>
         </div>
     </div>
+    {% endif %}
+
     <div class="row">
         <div class="section-alt">
             <h2 class="section__heading">Partners</h2>

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -248,6 +248,11 @@ class TestCaseStudyIndexChildPageCreation():
         case_study_index_page_title = 'test case study index page 2'
         create_about_child_page(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], case_study_index_page_title)
 
+    def text_no_case_studies_section_on_home(self, admin_browser):
+        """Before any case studies are published, test to see there is no Case studies section on the home page."""
+        admin_browser.visit(os.environ['LIVE_SERVER_URL'])
+        assert not admin_browser.is_text_present("Case studies")
+
     def test_can_create_case_study_page(self, admin_browser):
         """Check that a Case Study page can be created as a child of the Case Study Index page."""
         self.setup_case_study_index_page(admin_browser)
@@ -257,6 +262,9 @@ class TestCaseStudyIndexChildPageCreation():
         publish_page(admin_browser)
         view_live_page(admin_browser, CASE_STUDY_PAGE['title'])
         assert admin_browser.is_text_present(CASE_STUDY_PAGE['title'])
+
+    def text_case_studies_section_on_home(self, admin_browser):
+        """After one case study is published, check to see that the Case studies section has now appeared."""
         admin_browser.visit(os.environ['LIVE_SERVER_URL'])
         assert admin_browser.is_text_present("Case studies")
 

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -248,7 +248,7 @@ class TestCaseStudyIndexChildPageCreation():
         case_study_index_page_title = 'test case study index page 2'
         create_about_child_page(admin_browser, CASE_STUDY_INDEX_PAGE['page_type'], case_study_index_page_title)
 
-    def text_no_case_studies_section_on_home(self, admin_browser):
+    def test_no_case_studies_section_on_home(self, admin_browser):
         """Before any case studies are published, test to see there is no Case studies section on the home page."""
         admin_browser.visit(os.environ['LIVE_SERVER_URL'])
         assert not admin_browser.is_text_present("Case studies")
@@ -263,7 +263,7 @@ class TestCaseStudyIndexChildPageCreation():
         view_live_page(admin_browser, CASE_STUDY_PAGE['title'])
         assert admin_browser.is_text_present(CASE_STUDY_PAGE['title'])
 
-    def text_case_studies_section_on_home(self, admin_browser):
+    def test_case_studies_section_on_home(self, admin_browser):
         """After one case study is published, check to see that the Case studies section has now appeared."""
         admin_browser.visit(os.environ['LIVE_SERVER_URL'])
         assert admin_browser.is_text_present("Case studies")

--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -4,6 +4,7 @@ TODO:
     Refactor most of these tests out into base functional tests.
 
 """
+import os
 from django.utils.text import slugify
 import pytest
 
@@ -256,6 +257,8 @@ class TestCaseStudyIndexChildPageCreation():
         publish_page(admin_browser)
         view_live_page(admin_browser, CASE_STUDY_PAGE['title'])
         assert admin_browser.is_text_present(CASE_STUDY_PAGE['title'])
+        admin_browser.visit(os.environ['LIVE_SERVER_URL'])
+        assert admin_browser.is_text_present("Case studies")
 
     def test_can_edit_case_study_page_heading(self, admin_browser):
         """Check that Case Study page headings can be edited."""


### PR DESCRIPTION
A few short changes so case studies do not appear on the HomePage until there are case studies in the DB. Slightly tricky because I had to avoid a circular import from Home.models and About.models, but otherwise pretty straight forward.

Added test in about page models that checks to see if the case study section appears on the home page after publishing a case study page.