### PR TITLE
Add standard to default pages

### DIFF
--- a/iati/home/management/commands/createdefaultpages.py
+++ b/iati/home/management/commands/createdefaultpages.py
@@ -5,6 +5,7 @@ from contact.models import ContactPage
 from events.models import EventIndexPage
 from guidance_and_support.models import GuidanceAndSupportPage
 from news.models import NewsIndexPage
+from iati_standard.models import IATIStandardPage
 
 
 class Command(BaseCommand):
@@ -33,6 +34,7 @@ class Command(BaseCommand):
                 {"model": EventIndexPage, "title": "Events", "slug": "events"},
                 {"model": GuidanceAndSupportPage, "title": "Guidance and support", "slug": "guidance_and_support"},
                 {"model": NewsIndexPage, "title": "News", "slug": "news"},
+                {'model': IATIStandardPage, 'title': "IATI Standard", 'slug': 'iati_standard'}
             ]
 
             for default_page in default_pages:

--- a/iati/tests/base_functional_tests.py
+++ b/iati/tests/base_functional_tests.py
@@ -192,7 +192,8 @@ class TestDefaultPages():
         {'name': 'Contact', 'slug': 'contact'},
         {'name': 'Events', 'slug': 'events'},
         {'name': 'News', 'slug': 'news'},
-        {'name': 'Guidance and support', 'slug': 'guidance_and_support'}
+        {'name': 'Guidance and support', 'slug': 'guidance_and_support'},
+        {'name': 'IATI Standard', 'slug': 'iati_standard'}
     ]
 
     def navigate_to_edit_home_page(self, admin_browser, default_page_name):
@@ -231,6 +232,8 @@ class TestDefaultPages():
         browser.visit(LOCALHOST + '{}'.format(page_name['slug']))
         if page_name['slug'] == '':
             page_title = 'Home'
+        elif page_name['slug'] == 'iati_standard':
+            page_title = 'IATI Standard'
         else:
             page_title = page_name['slug'].replace('_', ' ').capitalize()
         assert browser.title == page_title

--- a/iati/tests/iati_standard_functional_tests.py
+++ b/iati/tests/iati_standard_functional_tests.py
@@ -4,20 +4,10 @@ from tests.base_functional_tests import click_obscured
 from tests.about_functional_tests import reveal_content_editor, scroll_to_bottom_of_page
 
 
-def create_IATI_Standard_page(admin_browser):
-    """Create an IATI Standard Page.
-
-    TODO:
-        Add line to click multilingual tab once editable header image branch gets merged in.
-
-    """
+def navigate_to_Home_cms_section(admin_browser):
+    """Navigate to the Home section of the CMS."""
     admin_browser.click_link_by_text('Pages')
     admin_browser.find_by_text('Home').click()
-    admin_browser.click_link_by_text('Add child page')
-    admin_browser.click_link_by_text('Iati standard page')
-    admin_browser.find_by_text('English')[0].click()
-    admin_browser.fill('title_en', 'IATI standard')
-    publish_changes(admin_browser)
 
 
 def publish_changes(admin_browser):
@@ -33,18 +23,6 @@ def view_live_page(admin_browser):
     admin_browser.visit(page_url)
 
 
-# I want to visit the IATI Standard page
-@pytest.mark.django_db
-class TestIATIStandardPageExists():
-    """Container for tests that assert the existence of an IATI Standard page."""
-
-    def test_IATI_Standard_page_exists(self, admin_browser):
-        """Check there is an IATI Standard landing page."""
-        create_IATI_Standard_page(admin_browser)
-        view_live_page(admin_browser)
-        assert admin_browser.title == 'IATI standard'
-
-
 @pytest.mark.django_db
 class TestIATIStandardPageisEditable():
     """Container for tests that an IATI Standard page is editable in expected ways."""
@@ -57,7 +35,8 @@ class TestIATIStandardPageisEditable():
             Add line to click multilingual tab once editable header image branch gets merged in.
 
         """
-        admin_browser.find_by_text('IATI standard').click()
+        navigate_to_Home_cms_section(admin_browser)
+        admin_browser.find_by_text('IATI Standard').click()
         admin_browser.find_by_text('English')[0].click()
         admin_browser.fill('heading_en', 'IATI Standard')
         publish_changes(admin_browser)
@@ -72,7 +51,8 @@ class TestIATIStandardPageisEditable():
             Add line to click multilingual tab once editable header image branch gets merged in.
 
         """
-        admin_browser.find_by_text('IATI standard').click()
+        navigate_to_Home_cms_section(admin_browser)
+        admin_browser.find_by_text('IATI Standard').click()
         admin_browser.find_by_text('English')[0].click()
         admin_browser.fill('excerpt_en', 'This is an excerpt.')
         publish_changes(admin_browser)
@@ -88,7 +68,8 @@ class TestIATIStandardPageisEditable():
             Add line to click multilingual tab once editable header image branch gets merged in.
 
         """
-        admin_browser.find_by_text('IATI standard').click()
+        navigate_to_Home_cms_section(admin_browser)
+        admin_browser.find_by_text('IATI Standard').click()
         admin_browser.find_by_text('English')[0].click()
         element_count = admin_browser.find_by_id('content_editor_en-count').value
         scroll_to_bottom_of_page(admin_browser)
@@ -109,7 +90,8 @@ class TestRedirectLinksWorking():
 
     def visit_iati_standard_page(self, admin_browser):
         """Go to the IATI Stadard page from the admin site."""
-        page_button = admin_browser.find_by_xpath('//a[@href="/en/iati-standard/"]').first
+        navigate_to_Home_cms_section(admin_browser)
+        page_button = admin_browser.find_by_xpath('//a[@href="/en/iati_standard/"]').first
         page_link = page_button._element.get_property('href')
         self.LOCALHOST_LINK = page_link[:-15]
         admin_browser.visit(page_link)


### PR DESCRIPTION
Add the IATI Standard landing page to `createdefaultpages` and update tests accordingly