### PR TITLE
Reference redirect

### DIFF
--- a/iati/home/views.py
+++ b/iati/home/views.py
@@ -1,0 +1,8 @@
+from django.shortcuts import redirect
+
+
+def reference_redirect(request, *args, **kwargs):
+    base_url = "http://reference.iatistandard.org"
+    slug = request.get_full_path()
+    redirection_url = base_url + slug
+    return redirect(to=redirection_url, permanent=True)

--- a/iati/home/views.py
+++ b/iati/home/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import redirect
 
 
 def reference_redirect(request, *args, **kwargs):
+    """A functional view that accepts any request starting with a version number."""
     base_url = "http://reference.iatistandard.org"
     slug = request.get_full_path()
     redirection_url = base_url + slug

--- a/iati/home/views.py
+++ b/iati/home/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import redirect
 
 
 def reference_redirect(request, *args, **kwargs):
-    """A functional view that accepts any request starting with a version number."""
+    """A functional view that accepts any request starting with a reference namespace."""
     base_url = "http://reference.iatistandard.org"
     slug = request.get_full_path()
     redirection_url = base_url + slug

--- a/iati/iati/urls.py
+++ b/iati/iati/urls.py
@@ -6,12 +6,15 @@ from django.conf.urls.i18n import i18n_patterns  # For internationalization
 from django.conf.urls.static import static
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
+from django.views.generic import RedirectView
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 from search import views as search_views
 from iati.activate_languages import i18n_patterns  # For internationalization
+
+from home.views import reference_redirect
 
 
 ADMIN_SLUG = "cms"
@@ -21,6 +24,10 @@ urlpatterns = [  # pylint: disable=invalid-name
     url(r'^django-{}/'.format(ADMIN_SLUG), admin.site.urls),
     url(r'^{}/'.format(ADMIN_SLUG), include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
+]
+
+urlpatterns += [
+    url(r'^(104|105|201|202|203)/', reference_redirect)
 ]
 
 urlpatterns += i18n_patterns(

--- a/iati/iati/urls.py
+++ b/iati/iati/urls.py
@@ -25,9 +25,34 @@ urlpatterns = [  # pylint: disable=invalid-name
     url(r'^documents/', include(wagtaildocs_urls)),
 ]
 
-urlpatterns += [
-    url(r'^(101|102|103|104|105|201|202|203)/', reference_redirect)
+
+reference_namespaces = [
+    "101",
+    "102",
+    "103",
+    "104",
+    "105",
+    "201",
+    "202",
+    "203",
+    "activity-standard",
+    "codelists",
+    "developer",
+    "introduction",
+    "namespaces-extensions",
+    "organisation-identifiers",
+    "organisation-standard",
+    "reference",
+    "rulesets",
+    "schema",
+    "upgrades"
 ]
+
+
+urlpatterns += [
+    url(r'^({})/'.format("|".join(reference_namespaces)), reference_redirect)
+]
+
 
 urlpatterns += i18n_patterns(
     # These URLs will have /<language_code>/ appended to the beginning

--- a/iati/iati/urls.py
+++ b/iati/iati/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [  # pylint: disable=invalid-name
 ]
 
 urlpatterns += [
-    url(r'^(104|105|201|202|203)/', reference_redirect)
+    url(r'^(101|102|103|104|105|201|202|203)/', reference_redirect)
 ]
 
 urlpatterns += i18n_patterns(

--- a/iati/iati/urls.py
+++ b/iati/iati/urls.py
@@ -6,7 +6,6 @@ from django.conf.urls.i18n import i18n_patterns  # For internationalization
 from django.conf.urls.static import static
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
-from django.views.generic import RedirectView
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls


### PR DESCRIPTION
Captures all urls that begin with a version number and redirects them to reference.iatistandard.org