### PR TITLE
Remove excerpt placeholder

### DIFF
--- a/iati/about/templates/about/about_sub_page.html
+++ b/iati/about/templates/about/about_sub_page.html
@@ -10,8 +10,7 @@
             <div class="hero__caption">
                 <h1 class="hero__heading">{{ page.heading }}</h1>
 
-                    <p class="hero__excerpt">{{ page.excerpt }}</p>
-
+                <p class="hero__excerpt">{{ page.excerpt|default:"" }}</p>
             </div>
             <div class="hero__emblem"></div>
         </div>

--- a/iati/about/templates/about/case_study_index_page.html
+++ b/iati/about/templates/about/case_study_index_page.html
@@ -32,7 +32,7 @@
             <h2 class="case-study__heading">
               <a href="{% slugurl_trans case_study.slug %}"><span>{{ case_study.heading }}</span></a>
             </h2>
-            <p class="case-study__excerpt">{{ case_study.excerpt }}</p>
+            <p class="case-study__excerpt">{{ case_study.excerpt|default:"" }}</p>
             <a href="{% slugurl_trans case_study.slug %}" class="button">Read more</a>
           </div>
         </article>

--- a/iati/about/templates/about/case_study_page.html
+++ b/iati/about/templates/about/case_study_page.html
@@ -15,7 +15,9 @@
     <div class="max-meter">
       <div class="hero__caption">
         <h1 class="hero__heading">{{ page.heading }}</h1>
-        <p class="hero__subheading">{{ page.excerpt }}</p>
+
+        <p class="hero__subheading">{{ page.excerpt|default:"" }}</p>
+
       </div>
     </div>
   </div>

--- a/iati/about/templates/about/history_page.html
+++ b/iati/about/templates/about/history_page.html
@@ -10,7 +10,7 @@
             <div class="hero__caption">
                 <h1 class="hero__heading">{{ page.heading }}</h1>
 
-                    <p class="hero__excerpt">{{ page.excerpt }}</p>
+                <p class="hero__excerpt">{{ page.excerpt|default:"" }}</p>
 
             </div>
             <div class="hero__emblem"></div>

--- a/iati/about/templates/about/people_page.html
+++ b/iati/about/templates/about/people_page.html
@@ -10,7 +10,7 @@
     <div class="hero__caption">
       <h1 class="hero__heading">{{ page.heading }}</h1>
 
-      <p class="hero__excerpt">{{ page.excerpt }}</p>
+      <p class="hero__excerpt">{{ page.excerpt|default:"" }}</p>
 
     </div>
     <div class="hero__emblem"></div>

--- a/iati/home/templates/home/home_page.html
+++ b/iati/home/templates/home/home_page.html
@@ -123,7 +123,7 @@
 
                               <div class="help__panel fill-sunset">
                                   <h3 class="help__heading">{{ case_study.heading }}</h3>
-                                  <p> {{ case_study.excerpt }}</p>
+                                  <p>{{ case_study.excerpt|default:"" }}</p>
                                   <a href="{% slugurl_trans case_study.slug %}">Read more</a>
                               </div>
                           </div>

--- a/iati/home/templates/home/includes/hero_heading.html
+++ b/iati/home/templates/home/includes/hero_heading.html
@@ -3,8 +3,9 @@
 <div class="row">
     <div class="hero__caption">
         <h1 class="hero__heading">{{ page.heading }}</h1>
-
-        <p class="hero__subheading">{{ page.excerpt }}</p>
+        {% if page.excerpt %}
+          <p class="hero__subheading">{{ page.excerpt }}</p>
+        {% endif %}
     </div>
     <div class="hero__emblem">
       {% if page.header_image %}

--- a/iati/home/templates/home/includes/hero_heading.html
+++ b/iati/home/templates/home/includes/hero_heading.html
@@ -3,9 +3,9 @@
 <div class="row">
     <div class="hero__caption">
         <h1 class="hero__heading">{{ page.heading }}</h1>
-        {% if page.excerpt %}
-          <p class="hero__subheading">{{ page.excerpt }}</p>
-        {% endif %}
+
+        <p class="hero__subheading">{{ page.excerpt|default:"" }}</p>
+
     </div>
     <div class="hero__emblem">
       {% if page.header_image %}


### PR DESCRIPTION
Stops 'None' appearing in the header when no excerpt is provided via the CMS.