### PR TITLE
Hide category and type boxes when empty

### DIFF
--- a/iati/events/templates/events/event_index_page.html
+++ b/iati/events/templates/events/event_index_page.html
@@ -91,6 +91,7 @@
       </div>
     {% endif %}
 
+    {% if event_type %}
     <div class="aside-m">
         <div class="aside-m__header fill-land">
             <h3 class="aside-m__heading">Event types</h3>
@@ -101,6 +102,7 @@
 	       {% endfor %}
         </ul>
     </div>
+    {% endif %}
     {% if past %}
     <div class="aside-m">
       <div class="aside-m__header fill-land">

--- a/iati/news/templates/news/news_index_page.html
+++ b/iati/news/templates/news/news_index_page.html
@@ -55,7 +55,7 @@
     </div>
     <aside class="l-sidebar__aside">
 
-
+    {% if news_category %}
       <div class="aside-m">
         <div class="aside-m__header fill-land">
           <h3 class="aside-m__heading">Categories</h3>
@@ -66,6 +66,7 @@
           {% endfor %}
         </ul>
       </div>
+    {% endif %}
 
     </aside>
   </div>


### PR DESCRIPTION
For the event index page hide the event type side box when there are no event types to choose from.
For the news index page hide the categories side box when there are no news categories to choose from.