### PR TITLE
Replace hard-coded URLs in home template

### DIFF
--- a/iati/home/templates/home/home_page.html
+++ b/iati/home/templates/home/home_page.html
@@ -46,7 +46,7 @@
                         </div>
                         <div class="help__body">
                             <p class="help__body-copy">Understand the ways you can access IATI data, what information you can find and the benefits of using it.</p>
-                            <a class="button" href="/using-data/">Explore IATI data</a>
+                            <a class="button" href="{% default_page_url 'using_data' %}">Explore IATI data</a>
                         </div>
                     </div>
                 </div>
@@ -59,7 +59,7 @@
                         </div>
                         <div class="help__body">
                             <p class="help__body-copy">Find out how to publish data to the IATI Standard and improve your data by using our publishing guidance.</p>
-                            <a class="button" href="/guidance/">Get started</a>
+                            <a class="button" href="{% default_page_url 'guidance_and_support' %}">Get started</a>
                         </div>
                     </div>
                 </div>
@@ -72,7 +72,7 @@
                         </div>
                         <div class="help__body">
                             <p class="help__body-copy">View IATI reference pages that contain the rules and technical framework for publishing and interpreting IATI data.</p>
-                            <a class="button" href="/iati-standard/">Find out more</a>
+                            <a class="button" href="{% default_page_url 'iati_standard' %}">Find out more</a>
                         </div>
                     </div>
                 </div>
@@ -89,7 +89,7 @@
                         <p>IATI is a global initiative to improve the transparency of development and humanitarian resources and their results for addressing poverty and crises.</p>
                         <p>IATI brings together governments, multilateral institutions, private sector and civil society organisations and others to increase the transparency of resources flowing into developing countries.</p>
                         <p>We encourage all organisations that distribute or spend resources to publish information about their development and humanitarian activities using IATI’s data standard. This is a set of rules and guidance to ensure information is easy to access, understand and use.</p>
-                        <a class="button" href="/about/">Find out more about IATI</a>
+                        <a class="button" href="{% default_page_url 'about' %}">Find out more about IATI</a>
                     </div>
                 </div>
                 <div class="l-2up__col">


### PR DESCRIPTION
I guess as good practice (and presumably for internationalisation) these should use template tags rather than hard-coding.

(NB I’ve not tested this at all; I haven’t even cloned the repo.)