### PR TITLE
Remove mention of add-page-models from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,10 @@ jobs:
             - pip install -r iati/requirements_dev.txt
           env: LINTER=flake8
           script: make flake8
-          if: branch IN (master, dev, add-page-models)
+          if: branch IN (master, dev)
         - stage: strict lint
           install:
             - pip install -r iati/requirements_dev.txt
           env: LINTER=pydocstyle
           script: make pydocstyle
-          if: branch IN (master, dev, add-page-models)
+          if: branch IN (master, dev)


### PR DESCRIPTION
Just a bit of tidying up.

This is leftover from testing linting on add-page-models. That branch is
gone now, so this doesn’t need to be here anymore.