### PR TITLE
Remove references to SQLite from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The current scope of the project (to April 2018) focuses on the 'About IATI' and
 ## Pre-requites
 
 - Python3
-- SQLite or PostgreSQL
+- PostgreSQL
 
 
 ## Dev setup
@@ -22,10 +22,9 @@ cd iati
 # Install requirements
 pip install -r requirements_dev.txt
 
-# Optional: Create a local PostgreSQL database (with appropriate user permissions)
+# Create a local PostgreSQL database (with appropriate user permissions)
 # Then, copy the example local settings file and enter database settings accordingly
 # Note local.py should not be under version control as it contains sensitive information
-# Without these steps, a SQLite database will be used to store data.
 createdb iati-website
 cp iati/settings/local.py.example iati/settings/local.py
 


### PR DESCRIPTION
SQLite isn’t supported (see #198). So this PR just updates the README to reflect that.