### PR TITLE
Lint first!!! Ask questions later!!!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ script:
   - make test
 
 stages:
-  - test
   - strict lint
+  - test
 
 jobs:
     include:


### PR DESCRIPTION
Make travis do linting before running tests.

Tests are super slow (#224) so it really sucks when they finish successfully and then linting fails.

In such cases, it makes more sense to Fail Fast™ and don’t bother testing if linting fails.