### PR TITLE
[COMPLETE] Move helpers from about page tests to base

### DIFF
--- a/iati/tests/about_functional_tests.py
+++ b/iati/tests/about_functional_tests.py
@@ -7,7 +7,7 @@ TODO:
 import os
 from django.utils.text import slugify
 import pytest
-from base_functional_tests import TEST_DATA_DIR, click_obscured, view_live_page
+from base_functional_tests import TEST_DATA_DIR, click_obscured, view_live_page, reveal_content_editor, scroll_to_bottom_of_page
 
 
 ABOUT_PAGE = {
@@ -119,28 +119,6 @@ def edit_page_header(admin_browser, page_title, cms_field, cms_content):
     enter_page_content(admin_browser, 'English', cms_field, cms_content)
     publish_page(admin_browser)
     view_live_page(admin_browser, page_title)
-
-
-def scroll_to_bottom_of_page(admin_browser):
-    """Scroll to the bottom of a page."""
-    admin_browser.driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-
-
-def reveal_content_editor(admin_browser, button, element_count):
-    """Open content editor if it is not already in view.
-
-    Args:
-        button (str): The displayed text name of the button you want to click.
-        element_count (str): The element counter value of the content editor Streamfield block.
-
-    TODO:
-        Decide whether on convert element_count to int on assignment of variable.
-
-    """
-    if not admin_browser.find_by_text(button).visible:
-        admin_browser.find_by_xpath('//div[@id="content_editor_en-{}-appendmenu"]/a'.format(int(element_count) - 1)).mouse_over()
-        admin_browser.find_by_xpath('//div[@id="content_editor_en-{}-appendmenu"]/a'.format(int(element_count) - 1)).click()
-        scroll_to_bottom_of_page(admin_browser)
 
 
 @pytest.mark.django_db

--- a/iati/tests/base_functional_tests.py
+++ b/iati/tests/base_functional_tests.py
@@ -186,6 +186,28 @@ def fill_content_editor_block(admin_browser, base_block, text_field_class, conte
         text_field.fill(content)
 
 
+def scroll_to_bottom_of_page(admin_browser):
+    """Scroll to the bottom of a page."""
+    admin_browser.driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+
+
+def reveal_content_editor(admin_browser, button, element_count):
+    """Open content editor if it is not already in view.
+
+    Args:
+        button (str): The displayed text name of the button you want to click.
+        element_count (str): The element counter value of the content editor Streamfield block.
+
+    TODO:
+        Decide whether on convert element_count to int on assignment of variable.
+
+    """
+    if not admin_browser.find_by_text(button).visible:
+        admin_browser.find_by_xpath('//div[@id="content_editor_en-{}-appendmenu"]/a'.format(int(element_count) - 1)).mouse_over()
+        admin_browser.find_by_xpath('//div[@id="content_editor_en-{}-appendmenu"]/a'.format(int(element_count) - 1)).click()
+        scroll_to_bottom_of_page(admin_browser)
+
+
 @pytest.mark.django_db()
 class TestCreateDefaultPagesManagementCommand():
     """A container for tests that check createdefaultpages command."""

--- a/iati/tests/iati_standard_functional_tests.py
+++ b/iati/tests/iati_standard_functional_tests.py
@@ -1,7 +1,6 @@
 """A module of functional tests for the IATI Standard page."""
 import pytest
-from tests.base_functional_tests import click_obscured
-from tests.about_functional_tests import reveal_content_editor, scroll_to_bottom_of_page, TEST_DATA_DIR, view_live_page
+from tests.base_functional_tests import click_obscured, reveal_content_editor, scroll_to_bottom_of_page, TEST_DATA_DIR, view_live_page
 
 
 def navigate_to_Home_cms_section(admin_browser):


### PR DESCRIPTION
iati_standard_functional_tests.py currently imports some helpers from its sibling about_functional_tests.py.

It’s maybe a bit clearer to import these from base_functional_tests.py instead? I’m not sure, really.