### PR TITLE
Update requirements_dev.txt

### DIFF
--- a/iati/requirements_dev.txt
+++ b/iati/requirements_dev.txt
@@ -3,6 +3,7 @@
 # Testing tools
 pytest==3.4.1
 pytest-django==3.1.2
+splinter==0.8.0
 pytest-splinter==1.8.5
 responses==0.9.0
 


### PR DESCRIPTION
Changing requirements_dev.txt to specify the version of splinter being used (0.8.0), since higher versions cause conflicts with pytest_splinter and phantomjs