### PR TITLE
Add missing closing divs to events pages

### DIFF
--- a/iati/events/templates/events/event_page.html
+++ b/iati/events/templates/events/event_page.html
@@ -72,5 +72,7 @@
       {% endif %}
 
     </div>
+  </div>
+</div>
 
-    {% endblock %}
+{% endblock %}


### PR DESCRIPTION
These closing tags were removed in 96d21b958cfd7c9d8dd9e241fdb631e2e2b78e24, breaking the markup (although it was broken in a different way before this).

As a result, events pages look broken and don’t work correctly on IE:

![screen shot 2018-09-10 at 11 58 13](https://user-images.githubusercontent.com/464193/45293780-0c394d00-b4f1-11e8-83bf-e84da9e6d8e4.png)

I guess this fixes the bug @yohannaloucheur reports here:
https://twitter.com/YohannaLoucheur/status/1038123054419726337