### PR TITLE
Remove static styles

### DIFF
--- a/iati/iati/templates/base.html
+++ b/iati/iati/templates/base.html
@@ -31,7 +31,6 @@
         </script>
 
         {# Global stylesheets #}
-        <link rel="stylesheet" type="text/css" href="{% static 'home/css/responsive.css' %}">
         <link rel="stylesheet" type="text/css" href="https://styles.iatistandard.org/assets/css/screen.min.css">
         <link href="https://fonts.googleapis.com/css?family=PT+Sans:400,400i,700" rel="stylesheet">
         <script>/*! grunt-grunticon Stylesheet Loader - v2.1.6 | https://github.com/filamentgroup/grunticon | (c) 2015 Scott Jehl, Filament Group, Inc. | MIT license. */


### PR DESCRIPTION
Removing reference to static css from base.html.

There was a card addressing the removal of static styles, do we want to remove the static files from the repository as well? @akmiller01 @samuele-mattiuzzo 