### PR TITLE
Remove notarticle=True for using_data templates

### DIFF
--- a/iati/using_data/templates/using_data/tools_index_page.html
+++ b/iati/using_data/templates/using_data/tools_index_page.html
@@ -32,7 +32,7 @@
 		<div class="l-sidebar__body">
 
       {% if page.content_editor %}
-        {% include "home/includes/streamfield.html" with content=page.content_editor notarticle=True %}
+        {% include "home/includes/streamfield.html" with content=page.content_editor %}
       {% endif %}
 
 		</div>

--- a/iati/using_data/templates/using_data/using_data_page.html
+++ b/iati/using_data/templates/using_data/using_data_page.html
@@ -18,7 +18,7 @@
     <div class="space-section-top">
           <div class="row">
             {% if page.content_editor %}
-              {% include "home/includes/streamfield.html" with content=page.content_editor notarticle=True %}
+              {% include "home/includes/streamfield.html" with content=page.content_editor %}
             {% endif %}
           </div>
       </div>


### PR DESCRIPTION
Ensuring all templates are using the `is-typeset--article` class to keep consistent font sizes across the site